### PR TITLE
Explicitly use utf-8 encoding

### DIFF
--- a/v0.5.0/nvidia/submission/code/rnn_translator/pytorch/scripts/downloaders/filter_dataset.py
+++ b/v0.5.0/nvidia/submission/code/rnn_translator/pytorch/scripts/downloaders/filter_dataset.py
@@ -49,7 +49,7 @@ def main():
     data1 = []
     data2 = []
 
-    with open(args.file1) as f1, open(args.file2) as f2:
+    with open(args.file1, encoding='utf-8') as f1, open(args.file2, encoding='utf-8') as f2:
         for idx, lines in enumerate(zip(f1, f2)):
             line1, line2 = lines
             if idx % 100000 == 1:


### PR DESCRIPTION
Since it's supposed to deal with non-ascii characters, it's better to ensure open the text file as 'utf-8' encoding.

It fixes my problem when post-processing the corpus.